### PR TITLE
Allow custom run folders

### DIFF
--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -558,6 +558,12 @@ if (opc.hasRawPropertySet('datagenRunFolder')) {
     datagenRunFolder = opc.getProperty('datagenRunFolder')
 }
 
+if (opc.isFeatureEnabled('runFolderPerVersion')) {
+    clientRunFolder += '/' + project.exactMinecraftVersion
+    serverRunFolder += '/' + project.exactMinecraftVersion
+    datagenRunFolder += '/' + project.exactMinecraftVersion
+}
+
 project.minecraft {
     copyIdeResources = true
     mappings channel: project.mappingsChannel, version: project.mappingsVersion

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -544,17 +544,17 @@ configurations { configContainer ->
 }
 
 def clientRunFolder = 'run'
-if (project.hasProperty('clientRunFolder')) {
+if (opc.hasRawPropertySet('clientRunFolder')) {
     clientRunFolder = opc.getProperty('clientRunFolder')
 }
 
 def serverRunFolder = 'run'
-if (project.hasProperty('serverRunFolder')) {
+if (opc.hasRawPropertySet('serverRunFolder')) {
     serverRunFolder = opc.getProperty('serverRunFolder')
 }
 
 def datagenRunFolder = 'run'
-if (project.hasProperty('datagenRunFolder')) {
+if (opc.hasRawPropertySet('datagenRunFolder')) {
     datagenRunFolder = opc.getProperty('datagenRunFolder')
 }
 

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -543,6 +543,21 @@ configurations { configContainer ->
     }
 }
 
+def clientRunFolder = 'run'
+if (project.hasProperty('clientRunFolder')) {
+    clientRunFolder = opc.getProperty('clientRunFolder')
+}
+
+def serverRunFolder = 'run'
+if (project.hasProperty('serverRunFolder')) {
+    serverRunFolder = opc.getProperty('serverRunFolder')
+}
+
+def datagenRunFolder = 'run'
+if (project.hasProperty('datagenRunFolder')) {
+    datagenRunFolder = opc.getProperty('datagenRunFolder')
+}
+
 project.minecraft {
     copyIdeResources = true
     mappings channel: project.mappingsChannel, version: project.mappingsVersion
@@ -550,7 +565,7 @@ project.minecraft {
 
     runs { runSpecContainer ->
         def clientSpec = runSpecContainer.maybeCreate("client")
-        clientSpec.workingDirectory project.file('run')
+        clientSpec.workingDirectory project.file(clientRunFolder)
         clientSpec.property 'forge.logging.markers', ''
         clientSpec.property 'forge.logging.console.level', 'info'
         clientSpec.property 'mixin.env.remapRefMap', 'true'
@@ -568,7 +583,7 @@ project.minecraft {
         }
 
         def serverSpec = runSpecContainer.maybeCreate("server")
-        serverSpec.workingDirectory project.file('run')
+        serverSpec.workingDirectory project.file(serverRunFolder)
         serverSpec.property 'forge.logging.markers', ''
         serverSpec.property 'forge.logging.console.level', 'info'
         serverSpec.property 'mixin.env.remapRefMap', 'true'
@@ -583,7 +598,7 @@ project.minecraft {
 
         if (opc.isFeatureEnabled("datagen")) {
             def dataSpec = runSpecContainer.maybeCreate("data")
-            dataSpec.workingDirectory project.file('run')
+            dataSpec.workingDirectory project.file(datagenRunFolder)
             dataSpec.property 'forge.logging.markers', ''
             dataSpec.property 'forge.logging.console.level', 'info'
             dataSpec.property 'mixin.env.remapRefMap', 'true'


### PR DESCRIPTION
- Allows you to split the run folders for the 3 different run specs (`clientRunFolder`, `serverRunFolder` and `datagenRunFolder`)
- Allows the run folders to be separated per MC version by using `usesRunFolderPerVersion`

Note: This does not actually require a gradle update in subprojects in case we don't want to add this.
`local.configuration.gradle` already supports modifying this per individual user. For example you can add:
```gradle
project.ext.setProperty('usesRunFolderPerVersion', 'true')
project.ext.setProperty('serverRunFolder', 'runServer')
```