### PR TITLE
Port OPC changes to NG7

### DIFF
--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -62,5 +62,5 @@ jobs:
         name: "🏗️ Build"
         run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
         env:
-          VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
-          VERSION_SUFFIX: "beta-${{ steps.computeBranchSuffix.outputs.branch_suffix }}"
+          MOD_VERSION: ${{ needs.compute-version.outputs.version }}
+          MOD_VERSION_SUFFIX: "beta-${{ steps.computeBranchSuffix.outputs.branch_suffix }}"

--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -23,28 +23,11 @@ permissions:
   contents: read
 
 jobs:
-  compute-suffix:
-    runs-on: ubuntu-latest
-    outputs:
-      branch_suffix: ${{ steps.computeBranchSuffix.outputs.branch_suffix }}
-    steps:
-      - id: computeBranchSuffix
-        name: "🔢 Compute branch suffix"
-        run: |
-          gitRef="${{ github.ref }}"
-          branchName=$(echo "${gitRef/refs\/heads\//}")
-          echo "Branch name: $branchName"
-          
-          cleanedBranchName=$(echo $branchName | sed 's/[^a-zA-Z0-9]/-/g')
-          echo "Cleaned branch name: $cleanedBranchName"
-          
-          echo "branch_suffix=$cleanedBranchName" >> "$GITHUB_OUTPUT"
-
   compute-version:
     uses: ./.github/workflows/gradle.version.yaml
 
   build:
-    needs: [ "compute-suffix", "compute-version" ]
+    needs: [ "compute-version" ]
     runs-on: ubuntu-latest
     steps:
       - id: checkout
@@ -63,9 +46,21 @@ jobs:
           gradle-version: wrapper
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      - id: computeBranchSuffix
+        name: "🔢 Compute branch suffix"
+        run: |
+          gitRef="${{ github.ref }}"
+          branchName=$(echo "${gitRef/refs\/heads\//}")
+          echo "Branch name: $branchName"
+          
+          cleanedBranchName=$(echo $branchName | sed 's/[^a-zA-Z0-9]/-/g')
+          echo "Cleaned branch name: $cleanedBranchName"
+          
+          echo "branch_suffix=$cleanedBranchName" >> "$GITHUB_OUTPUT"
+
       - id: build
         name: "🏗️ Build"
         run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
         env:
           VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
-          VERSION_SUFFIX: "beta-${{ steps.compute-suffix.outputs.branch_suffix }}"
+          VERSION_SUFFIX: "beta-${{ steps.computeBranchSuffix.outputs.branch_suffix }}"

--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -68,6 +68,7 @@ jobs:
 
       - id: build
         name: "🏗️ Build"
-        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
+        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }} testArtifactName # TODO: REMOVE
         env:
+          CUSTOM_CURSE_FILE_NAME: "Minecolonies - ${{ needs.compute-version.outputs.minecraft_version }}" # TODO: REMOVE
           Version: "${{ needs.compute-version.outputs.version }}"

--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -23,28 +23,8 @@ permissions:
   contents: read
 
 jobs:
-  compute-suffix:
-    runs-on: ubuntu-latest
-    outputs:
-      branch_suffix: ${{ steps.computeBranchSuffix.outputs.branch_suffix }}
-    steps:
-      - id: computeBranchSuffix
-        name: "🔢 Compute branch suffix"
-        run: |
-          gitRef="${{ github.ref }}"
-          branchName=$(echo "${gitRef/refs\/heads\//}")
-          echo "Branch name: $branchName"
-          
-          cleanedBranchName=$(echo $branchName | sed 's/[^a-zA-Z0-9]/-/g')
-          echo "Cleaned branch name: $cleanedBranchName"
-          
-          echo "branch_suffix=$cleanedBranchName" >> "$GITHUB_OUTPUT"
-
   compute-version:
-    needs: [ "compute-suffix" ]
     uses: ./.github/workflows/gradle.version.yaml
-    with:
-      suffix: ${{ format('branch-{0}', needs.compute-suffix.outputs.branch_suffix) }}
 
   build:
     needs: [ "compute-version" ]

--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -68,7 +68,6 @@ jobs:
 
       - id: build
         name: "🏗️ Build"
-        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }} testArtifactName # TODO: REMOVE
+        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
         env:
-          CUSTOM_CURSE_FILE_NAME: "Minecolonies - ${{ needs.compute-version.outputs.minecraft_version }}" # TODO: REMOVE
           Version: "${{ needs.compute-version.outputs.version }}"

--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -67,4 +67,5 @@ jobs:
         name: "🏗️ Build"
         run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
         env:
-          Version: "${{ needs.compute-version.outputs.version }}-${{ needs.compute-version.outputs.minecraft_version }}-build-${{ steps.compute-suffix.outputs.branch_suffix }}"
+          VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
+          VERSION_SUFFIX: "beta-${{ steps.compute-suffix.outputs.branch_suffix }}"

--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -23,8 +23,28 @@ permissions:
   contents: read
 
 jobs:
+  compute-suffix:
+    runs-on: ubuntu-latest
+    outputs:
+      branch_suffix: ${{ steps.computeBranchSuffix.outputs.branch_suffix }}
+    steps:
+      - id: computeBranchSuffix
+        name: "🔢 Compute branch suffix"
+        run: |
+          gitRef="${{ github.ref }}"
+          branchName=$(echo "${gitRef/refs\/heads\//}")
+          echo "Branch name: $branchName"
+          
+          cleanedBranchName=$(echo $branchName | sed 's/[^a-zA-Z0-9]/-/g')
+          echo "Cleaned branch name: $cleanedBranchName"
+          
+          echo "branch_suffix=$cleanedBranchName" >> "$GITHUB_OUTPUT"
+
   compute-version:
+    needs: [ "compute-suffix" ]
     uses: ./.github/workflows/gradle.version.yaml
+    with:
+      suffix: ${{ format('branch-{0}', needs.compute-suffix.outputs.branch_suffix) }}
 
   build:
     needs: [ "compute-version" ]

--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -41,13 +41,10 @@ jobs:
           echo "branch_suffix=$cleanedBranchName" >> "$GITHUB_OUTPUT"
 
   compute-version:
-    needs: [ "compute-suffix" ]
     uses: ./.github/workflows/gradle.version.yaml
-    with:
-      suffix: ${{ format('branch-{0}', needs.compute-suffix.outputs.branch_suffix) }}
 
   build:
-    needs: [ "compute-version" ]
+    needs: [ "compute-suffix", "compute-version" ]
     runs-on: ubuntu-latest
     steps:
       - id: checkout
@@ -70,4 +67,4 @@ jobs:
         name: "🏗️ Build"
         run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
         env:
-          Version: "${{ needs.compute-version.outputs.version }}"
+          Version: "${{ needs.compute-version.outputs.version }}-${{ needs.compute-version.outputs.minecraft_version }}-build-${{ steps.compute-suffix.outputs.branch_suffix }}"

--- a/.github/workflows/gradle.prerelease.yaml
+++ b/.github/workflows/gradle.prerelease.yaml
@@ -61,5 +61,5 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_USERNAME: ${{ github.actor }}
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
-          VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
-          VERSION_SUFFIX: rc
+          MOD_VERSION: ${{ needs.compute-version.outputs.version }}
+          MOD_VERSION_SUFFIX: rc

--- a/.github/workflows/gradle.prerelease.yaml
+++ b/.github/workflows/gradle.prerelease.yaml
@@ -61,4 +61,5 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_USERNAME: ${{ github.actor }}
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
-          Version: "${{ needs.compute-version.outputs.version }}-${{ needs.compute-version.outputs.minecraft_version }}-rc"
+          VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
+          VERSION_SUFFIX: rc

--- a/.github/workflows/gradle.prerelease.yaml
+++ b/.github/workflows/gradle.prerelease.yaml
@@ -29,6 +29,8 @@ permissions:
 jobs:
   compute-version:
     uses: ./.github/workflows/gradle.version.yaml
+    with:
+      suffix: pre-release
 
   gradle:
     needs: [ "compute-version" ]

--- a/.github/workflows/gradle.prerelease.yaml
+++ b/.github/workflows/gradle.prerelease.yaml
@@ -29,8 +29,6 @@ permissions:
 jobs:
   compute-version:
     uses: ./.github/workflows/gradle.version.yaml
-    with:
-      suffix: pre-release
 
   gradle:
     needs: [ "compute-version" ]

--- a/.github/workflows/gradle.prerelease.yaml
+++ b/.github/workflows/gradle.prerelease.yaml
@@ -1,5 +1,5 @@
 # Based off https://github.com/MinecraftForge/SharedActions/blob/main/.github/workflows/gradle.yml
-name: Gradle Building CI
+name: Gradle Pre-release CI
 
 on:
   workflow_call:
@@ -13,46 +13,35 @@ on:
         description: "The Gradle task(s) to run for building"
         required: false
         type: string
-        default: "build"
+        default: "publish"
     secrets:
       GRADLE_ENCRYPTION_KEY:
         description: The AES key to enable Gradle cache encryption
-        required: false
+        required: true
+      CROWDIN_API_KEY:
+        required: true
 
 permissions:
   contents: read
+  statuses: write
+  packages: write
 
 jobs:
-  compute-suffix:
-    runs-on: ubuntu-latest
-    outputs:
-      branch_suffix: ${{ steps.computeBranchSuffix.outputs.branch_suffix }}
-    steps:
-      - id: computeBranchSuffix
-        name: "🔢 Compute branch suffix"
-        run: |
-          gitRef="${{ github.ref }}"
-          branchName=$(echo "${gitRef/refs\/heads\//}")
-          echo "Branch name: $branchName"
-          
-          cleanedBranchName=$(echo $branchName | sed 's/[^a-zA-Z0-9]/-/g')
-          echo "Cleaned branch name: $cleanedBranchName"
-          
-          echo "branch_suffix=$cleanedBranchName" >> "$GITHUB_OUTPUT"
-
   compute-version:
-    needs: [ "compute-suffix" ]
     uses: ./.github/workflows/gradle.version.yaml
     with:
-      suffix: ${{ format('branch-{0}', needs.compute-suffix.outputs.branch_suffix) }}
+      suffix: pre-release
 
-  build:
+  gradle:
     needs: [ "compute-version" ]
     runs-on: ubuntu-latest
     steps:
       - id: checkout
         name: "📦 Checkout"
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1000
+          fetch-tags: true
 
       - id: setupJava
         name: "🔧 Setup Java"
@@ -70,4 +59,8 @@ jobs:
         name: "🏗️ Build"
         run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
         env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_USERNAME: ${{ github.actor }}
+          crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
           Version: "${{ needs.compute-version.outputs.version }}"

--- a/.github/workflows/gradle.prerelease.yaml
+++ b/.github/workflows/gradle.prerelease.yaml
@@ -29,8 +29,6 @@ permissions:
 jobs:
   compute-version:
     uses: ./.github/workflows/gradle.version.yaml
-    with:
-      suffix: pre-release
 
   gradle:
     needs: [ "compute-version" ]
@@ -63,4 +61,4 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_USERNAME: ${{ github.actor }}
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
-          Version: "${{ needs.compute-version.outputs.version }}"
+          Version: "${{ needs.compute-version.outputs.version }}-${{ needs.compute-version.outputs.minecraft_version }}-rc"

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -122,7 +122,7 @@ jobs:
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
-          Version: "${{ needs.compute-version.outputs.version }}"
+          Version: "${{ needs.compute-version.outputs.version }}-${{ needs.compute-version.outputs.minecraft_version }}${{ inputs.curse_release_type != 'release' && format('-{1}', inputs.curse_release_type) }}"
 
       - name: "🚀 Create GitHub release"
         uses: actions/create-release@v1

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -124,6 +124,7 @@ jobs:
           fi
           echo "Release version suffix: ${release_version_suffix}"
           echo "release_version_suffix=${release_version_suffix}" >> "$GITHUB_ENV"
+          ./gradlew # Prevent download message from appearing inside the getProjectName output
           echo "mod_name=$(./gradlew --build-cache getProjectName)" >> "$GITHUB_ENV"
 
       - id: publish

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -137,8 +137,8 @@ jobs:
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
           CUSTOM_CURSE_FILE_NAME: "${{ steps.generate-release-information.outputs.mod_name }} - ${{ needs.compute-version.outputs.version }} - ${{ inputs.curse_release_type }}"
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
-          VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
-          VERSION_SUFFIX: ${{ steps.generate-release-suffix.outputs.release_version_suffix }}
+          MOD_VERSION: ${{ needs.compute-version.outputs.version }}
+          MOD_VERSION_SUFFIX: ${{ steps.generate-release-suffix.outputs.release_version_suffix }}
 
       - name: "🚀 Create GitHub release"
         uses: actions/create-release@v1

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -126,7 +126,7 @@ jobs:
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
-          CUSTOM_CURSE_FILENAME: "${{ steps.get-mod-name.outputs.mod_name }} - ${{ needs.compute-version.outputs.minecraft_version }}"
+          CUSTOM_CURSE_FILE_NAME: "${{ steps.get-mod-name.outputs.mod_name }} - ${{ needs.compute-version.outputs.minecraft_version }}"
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
           Version: "${{ needs.compute-version.outputs.version }}"
 

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -132,6 +132,7 @@ jobs:
           LDTTeamJfrogUsername: ${{ secrets.MAVEN_USER }}
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
+          CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
           VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
           VERSION_SUFFIX: ${{ steps.generate-release-suffix.outputs.release_version_suffix }}

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       java:
-        description: "The version of Java to use to run Gradle" # Note: Gradle's Java toolchains feature is used for compiling, which is separate from this
+        description: "The version of Java to use to run Gradle"
         required: false
         type: string
         default: "21"
@@ -24,23 +24,19 @@ on:
         required: false
         type: number
         default: 100
-
     secrets:
       DISCORD_WEBHOOK:
         required: true
-
       MAVEN_USER:
         required: true
       MAVEN_PASSWORD:
         required: true
-
       CURSE_API_KEY:
         required: true
-
       CROWDIN_API_KEY:
         required: true
-
       GRADLE_ENCRYPTION_KEY:
+        description: The AES key to enable Gradle cache encryption
         required: true
 
 permissions:
@@ -49,39 +45,12 @@ permissions:
 
 jobs:
   compute-version:
-    name: Compute version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      version_tag: ${{ steps.version.outputs.version_tag }}
-      minecraft_version: ${{ steps.minecraftVersion.outputs.minecraft_version }}
-    steps:
-      - id: checkout
-        name: "📦 Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - id: minecraftVersion
-        name: "📦 Extract Minecraft version"
-        run: |
-          cat gradle.properties | grep exactMinecraftVersion | cut -d "=" -f 2 > minecraft_version.txt
-          echo "Minecraft version: $(cat minecraft_version.txt)"
-          echo "minecraft_version=$(cat minecraft_version.txt)" >> "$GITHUB_OUTPUT"  
-
-      - id: version
-        name: "🔢 Compute version"
-        uses: PaulHatch/semantic-version@v5.4.0
-        with:
-          tag_prefix: "v"
-          search_commit_body: true
-          debug: true
-          bump_each_commit: true
-          version_format: "${major}.${minor}.${patch}-${{ steps.minecraftVersion.outputs.minecraft_version }}-${{ inputs.curse_release_type }}"
+    uses: ./.github/workflows/gradle.version.yaml
+    with:
+      suffix: ${{ inputs.curse_release_type }}
 
   notify-build-start:
-    needs: ["compute-version"]
+    needs: [ "compute-version" ]
     name: "🔴 Build notifications (start)"
     runs-on: ubuntu-latest
     steps:
@@ -104,7 +73,7 @@ jobs:
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   gradle:
-    needs: ["compute-version"] # Make sure we now the version before starting to build
+    needs: [ "compute-version" ]
     runs-on: ubuntu-latest
     steps:
       - id: checkout
@@ -116,8 +85,6 @@ jobs:
 
       - id: setupJava
         name: "🔧 Setup Java"
-        # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java
-        # language=bash
         run: |
           echo "JAVA_HOME=$(echo $JAVA_HOME_${{ inputs.java }}_X64)" >> "$GITHUB_ENV"
 
@@ -146,6 +113,11 @@ jobs:
           onlyLastTag: true
           maxIssues: ${{ inputs.changelog_max_issues }}
 
+      - id: get-mod-name
+        name: Get mod name
+        run: |
+          echo "mod_name=$(./gradlew --build-cache projectName)" >> "$GITHUB_ENV"
+
       - id: publish
         name: "🚀 Publish"
         run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
@@ -154,6 +126,7 @@ jobs:
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
+          CUSTOM_CURSE_FILENAME: "${{ steps.get-mod-name.outputs.mod_name }}"
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
           Version: "${{ needs.compute-version.outputs.version }}"
 

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -113,6 +113,18 @@ jobs:
           onlyLastTag: true
           maxIssues: ${{ inputs.changelog_max_issues }}
 
+      - id: generate-release-suffix
+        name: "Generate release suffix"
+        run: |
+          release_version_suffix = "alpha"
+          if [[ ${{ inputs.curse_release_type }} == release ]]; then
+            release_version_suffix = ""
+          elif [[ ${{ inputs.curse_release_type }} == beta ]]; then
+            release_version_suffix = "snapshot"
+          fi
+          echo "Release version suffix: ${release_version_suffix}"
+          echo "release_version_suffix=${release_version_suffix}" >> "$GITHUB_ENV"
+
       - id: publish
         name: "🚀 Publish"
         run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
@@ -120,9 +132,9 @@ jobs:
           LDTTeamJfrogUsername: ${{ secrets.MAVEN_USER }}
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
-          CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
-          Version: "${{ needs.compute-version.outputs.version }}-${{ needs.compute-version.outputs.minecraft_version }}${{ inputs.curse_release_type != 'release' && format('-{1}', inputs.curse_release_type) }}"
+          VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
+          VERSION_SUFFIX: ${{ steps.generate-release-suffix.outputs.release_version_suffix }}
 
       - name: "🚀 Create GitHub release"
         uses: actions/create-release@v1

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -46,6 +46,8 @@ permissions:
 jobs:
   compute-version:
     uses: ./.github/workflows/gradle.version.yaml
+    with:
+      suffix: ${{ inputs.curse_release_type }}
 
   notify-build-start:
     needs: [ "compute-version" ]

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -126,7 +126,7 @@ jobs:
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
-          CUSTOM_CURSE_FILENAME: "${{ steps.get-mod-name.outputs.mod_name }}"
+          CUSTOM_CURSE_FILENAME: "${{ steps.get-mod-name.outputs.mod_name }} - ${{ needs.compute-version.outputs.minecraft_version }}"
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
           Version: "${{ needs.compute-version.outputs.version }}"
 

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -113,8 +113,8 @@ jobs:
           onlyLastTag: true
           maxIssues: ${{ inputs.changelog_max_issues }}
 
-      - id: generate-release-suffix
-        name: "Generate release suffix"
+      - id: generate-release-information
+        name: "Generate release information"
         run: |
           release_version_suffix = "alpha"
           if [[ ${{ inputs.curse_release_type }} == release ]]; then
@@ -124,6 +124,7 @@ jobs:
           fi
           echo "Release version suffix: ${release_version_suffix}"
           echo "release_version_suffix=${release_version_suffix}" >> "$GITHUB_ENV"
+          echo "mod_name=$(./gradlew --build-cache getProjectName)" >> "$GITHUB_ENV"
 
       - id: publish
         name: "🚀 Publish"
@@ -133,6 +134,7 @@ jobs:
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
+          CUSTOM_CURSE_FILE_NAME: "${{ steps.generate-release-information.outputs.mod_name }} - ${{ needs.compute-version.outputs.version }} - ${{ inputs.curse_release_type }}"
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
           VERSION_NUMBER: ${{ needs.compute-version.outputs.version }}
           VERSION_SUFFIX: ${{ steps.generate-release-suffix.outputs.release_version_suffix }}

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -113,11 +113,6 @@ jobs:
           onlyLastTag: true
           maxIssues: ${{ inputs.changelog_max_issues }}
 
-      - id: get-mod-name
-        name: Get mod name
-        run: |
-          echo "mod_name=$(./gradlew --build-cache projectName)" >> "$GITHUB_ENV"
-
       - id: publish
         name: "🚀 Publish"
         run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
@@ -126,7 +121,6 @@ jobs:
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
-          CUSTOM_CURSE_FILE_NAME: "${{ steps.get-mod-name.outputs.mod_name }} - ${{ needs.compute-version.outputs.minecraft_version }}"
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
           Version: "${{ needs.compute-version.outputs.version }}"
 

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -124,8 +124,6 @@ jobs:
           fi
           echo "Release version suffix: ${release_version_suffix}"
           echo "release_version_suffix=${release_version_suffix}" >> "$GITHUB_ENV"
-          ./gradlew # Prevent download message from appearing inside the getProjectName output
-          echo "mod_name=$(./gradlew --build-cache getProjectName)" >> "$GITHUB_ENV"
 
       - id: publish
         name: "🚀 Publish"
@@ -135,7 +133,6 @@ jobs:
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
-          CUSTOM_CURSE_FILE_NAME: "${{ steps.generate-release-information.outputs.mod_name }} - ${{ needs.compute-version.outputs.version }} - ${{ inputs.curse_release_type }}"
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
           MOD_VERSION: ${{ needs.compute-version.outputs.version }}
           MOD_VERSION_SUFFIX: ${{ steps.generate-release-suffix.outputs.release_version_suffix }}

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -46,8 +46,6 @@ permissions:
 jobs:
   compute-version:
     uses: ./.github/workflows/gradle.version.yaml
-    with:
-      suffix: ${{ inputs.curse_release_type }}
 
   notify-build-start:
     needs: [ "compute-version" ]

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -48,4 +48,4 @@ jobs:
           search_commit_body: true
           debug: true
           bump_each_commit: true
-          version_format: "${major}.${minor}.${patch}-${{ inputs.suffix }}"
+          version_format: "${{ steps.minecraftVersion.outputs.minecraft_version }}-${major}.${minor}.${patch}-${{ inputs.suffix }}"

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -12,9 +12,6 @@ on:
       version:
         description: "The computed version"
         value: ${{ jobs.compute-version.outputs.version }}
-      minecraft_version:
-        description: "The minecraft version"
-        value: ${{ jobs.compute-version.outputs.minecraft_version }}
 
 permissions:
   contents: read
@@ -24,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      minecraft_version: ${{ steps.minecraftVersion.outputs.minecraft_version }}
     steps:
       - id: checkout
         name: "📦 Checkout"

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -1,0 +1,51 @@
+name: Common Version Determination CI
+
+on:
+  workflow_call:
+    inputs:
+      suffix:
+        description: "The suffix to finish the version string with"
+        required: false
+        type: string
+        default: ""
+    outputs:
+      version:
+        description: "The computed version"
+        value: ${{ jobs.compute-version.outputs.version }}
+      minecraft_version:
+        description: "The minecraft version"
+        value: ${{ jobs.compute-version.outputs.minecraft_version }}
+
+permissions:
+  contents: read
+
+jobs:
+  compute-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      minecraft_version: ${{ steps.minecraftVersion.outputs.minecraft_version }}
+    steps:
+      - id: checkout
+        name: "📦 Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: minecraftVersion
+        name: "📦 Extract Minecraft version"
+        run: |
+          cat gradle.properties | grep exactMinecraftVersion | cut -d "=" -f 2 > minecraft_version.txt
+          echo "Minecraft version: $(cat minecraft_version.txt)"
+          echo "minecraft_version=$(cat minecraft_version.txt)" >> "$GITHUB_OUTPUT"
+
+      - id: version
+        name: "🔢 Compute version"
+        uses: PaulHatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          search_commit_body: true
+          debug: true
+          bump_each_commit: true
+          version_format: "${major}.${minor}.${patch}-${{ inputs.suffix }}"

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -6,6 +6,9 @@ on:
       version:
         description: "The computed version"
         value: ${{ jobs.compute-version.outputs.version }}
+      minecraft_version:
+        description: "The minecraft version"
+        value: ${{ jobs.compute-version.outputs.minecraft_version }}
 
 permissions:
   contents: read
@@ -15,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      minecraft_version: ${{ steps.minecraftVersion.outputs.minecraft_version }}
     steps:
       - id: checkout
         name: "📦 Checkout"
@@ -22,6 +26,13 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - id: minecraftVersion
+        name: "📦 Extract Minecraft version"
+        run: |
+          cat gradle.properties | grep exactMinecraftVersion | cut -d "=" -f 2 > minecraft_version.txt
+          echo "Minecraft version: $(cat minecraft_version.txt)"
+          echo "minecraft_version=$(cat minecraft_version.txt)" >> "$GITHUB_OUTPUT"
 
       - id: version
         name: "🔢 Compute version"

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -2,6 +2,12 @@ name: Common Version Determination CI
 
 on:
   workflow_call:
+    inputs:
+      suffix:
+        description: "The suffix to finish the version string with"
+        required: false
+        type: string
+        default: ""
     outputs:
       version:
         description: "The computed version"
@@ -42,4 +48,4 @@ jobs:
           search_commit_body: true
           debug: true
           bump_each_commit: true
-          version_format: "${major}.${minor}.${patch}"
+          version_format: "${major}.${minor}.${patch}-${{ inputs.suffix }}"

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -2,12 +2,6 @@ name: Common Version Determination CI
 
 on:
   workflow_call:
-    inputs:
-      suffix:
-        description: "The suffix to finish the version string with"
-        required: false
-        type: string
-        default: ""
     outputs:
       version:
         description: "The computed version"
@@ -48,4 +42,4 @@ jobs:
           search_commit_body: true
           debug: true
           bump_each_commit: true
-          version_format: "${major}.${minor}.${patch}-${{ inputs.suffix }}"
+          version_format: "${major}.${minor}.${patch}"

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -6,9 +6,6 @@ on:
       version:
         description: "The computed version"
         value: ${{ jobs.compute-version.outputs.version }}
-      minecraft_version:
-        description: "The minecraft version"
-        value: ${{ jobs.compute-version.outputs.minecraft_version }}
 
 permissions:
   contents: read
@@ -18,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      minecraft_version: ${{ steps.minecraftVersion.outputs.minecraft_version }}
     steps:
       - id: checkout
         name: "📦 Checkout"
@@ -26,13 +22,6 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-
-      - id: minecraftVersion
-        name: "📦 Extract Minecraft version"
-        run: |
-          cat gradle.properties | grep exactMinecraftVersion | cut -d "=" -f 2 > minecraft_version.txt
-          echo "Minecraft version: $(cat minecraft_version.txt)"
-          echo "minecraft_version=$(cat minecraft_version.txt)" >> "$GITHUB_OUTPUT"
 
       - id: version
         name: "🔢 Compute version"

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -2,16 +2,13 @@ name: Common Version Determination CI
 
 on:
   workflow_call:
-    inputs:
-      suffix:
-        description: "The suffix to finish the version string with"
-        required: false
-        type: string
-        default: ""
     outputs:
       version:
         description: "The computed version"
         value: ${{ jobs.compute-version.outputs.version }}
+      minecraft_version:
+        description: "The minecraft version"
+        value: ${{ jobs.compute-version.outputs.minecraft_version }}
 
 permissions:
   contents: read
@@ -21,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      minecraft_version: ${{ steps.minecraftVersion.outputs.minecraft_version }}
     steps:
       - id: checkout
         name: "📦 Checkout"
@@ -44,4 +42,4 @@ jobs:
           search_commit_body: true
           debug: true
           bump_each_commit: true
-          version_format: "${{ steps.minecraftVersion.outputs.minecraft_version }}-${major}.${minor}.${patch}-${{ inputs.suffix }}"
+          version_format: "${major}.${minor}.${patch}"

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1040,12 +1040,12 @@ if (opc.isFeatureEnabled("curse") && opc.hasPropertySet("curseId")
 
         mainArtifact.releaseType = opc.hasPropertySet("curseReleaseType") ? opc.getProperty("curseReleaseType") : opc.getProperty("CURSERELEASETYPE")
         if (opc.isFeatureEnabled('reformatedCurseFiles')) {
-            def mainArtifactName = rootProject.name + " - " + project.version + " - " + mainArtifact.releaseType
+            def mainArtifactName = rootProject.name
             if (opc.isFeatureEnabled('customCurseFileName')) {
                 mainArtifactName = opc.getProperty('customCurseFileName')
             }
 
-            mainArtifact.displayName = mainArtifactName
+            mainArtifact.displayName = mainArtifactName + " - " + project.version + " - " + mainArtifact.releaseType
         }
 
         mainArtifact.changelog = project.rootProject.file("changelog.md")

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1040,7 +1040,7 @@ if (opc.isFeatureEnabled("curse") && opc.hasPropertySet("curseId")
                 mainArtifactName = opc.getProperty('customCurseFileName')
             }
 
-            mainArtifact.displayName = mainArtifactName + " - " + project.version + " - " + mainArtifact.releaseType
+            mainArtifact.displayName = mainArtifactName + " - " + project.version
         }
 
         mainArtifact.changelog = project.rootProject.file("changelog.md")

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1154,14 +1154,14 @@ tasks.withType(Jar.class, {task ->
     task.duplicatesStrategy 'exclude'
 })
 
-tasks.named('getProjectName', Task.class, { task ->
+tasks.register('getProjectName', Task.class) {
     print rootProject.name
-})
+}
 
 // TODO: REMOVE
-tasks.named('testArtifactName', Task.class, { task ->
+tasks.register('testArtifactName', Task.class) {
     println opc.getProperty('customCurseFileName') + " - " + project.version
-})
+}
 
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {
     task mergeTranslations {

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1040,12 +1040,12 @@ if (opc.isFeatureEnabled("curse") && opc.hasPropertySet("curseId")
 
         mainArtifact.releaseType = opc.hasPropertySet("curseReleaseType") ? opc.getProperty("curseReleaseType") : opc.getProperty("CURSERELEASETYPE")
         if (opc.isFeatureEnabled('reformatedCurseFiles')) {
-            def mainArtifactName = rootProject.name
+            def mainArtifactName = rootProject.name + " - " + project.version + " - " + mainArtifact.releaseType
             if (opc.isFeatureEnabled('customCurseFileName')) {
                 mainArtifactName = opc.getProperty('customCurseFileName')
             }
 
-            mainArtifact.displayName = mainArtifactName + " - " + project.version + " - " + mainArtifact.releaseType
+            mainArtifact.displayName = mainArtifactName
         }
 
         mainArtifact.changelog = project.rootProject.file("changelog.md")
@@ -1158,6 +1158,12 @@ tasks.withType(org.gradle.api.tasks.javadoc.Javadoc.class, {task ->
 tasks.withType(Jar.class, {task ->
     task.duplicatesStrategy 'exclude'
 })
+
+tasks.register('getProjectName', Task.class) {
+    doLast {
+        print rootProject.name
+    }
+}
 
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {
     task mergeTranslations {

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1160,13 +1160,6 @@ tasks.register('getProjectName', Task.class) {
     }
 }
 
-// TODO: REMOVE
-tasks.register('testArtifactName', Task.class) {
-    doLast {
-        println opc.getProperty('customCurseFileName') + " - " + project.version
-    }
-}
-
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {
     task mergeTranslations {
         doLast {

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1154,12 +1154,6 @@ tasks.withType(Jar.class, {task ->
     task.duplicatesStrategy 'exclude'
 })
 
-tasks.register('getProjectName', Task.class) {
-    doLast {
-        print rootProject.name
-    }
-}
-
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {
     task mergeTranslations {
         doLast {

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1154,6 +1154,10 @@ tasks.withType(Jar.class, {task ->
     task.duplicatesStrategy 'exclude'
 })
 
+tasks.named('projectName', Task.class, { task ->
+    print rootProject.name
+})
+
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {
     task mergeTranslations {
         doLast {

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1155,12 +1155,16 @@ tasks.withType(Jar.class, {task ->
 })
 
 tasks.register('getProjectName', Task.class) {
-    print rootProject.name
+    doLast {
+        print rootProject.name
+    }
 }
 
 // TODO: REMOVE
 tasks.register('testArtifactName', Task.class) {
-    println opc.getProperty('customCurseFileName') + " - " + project.version
+    doLast {
+        println opc.getProperty('customCurseFileName') + " - " + project.version
+    }
 }
 
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -283,8 +283,8 @@ if (opc.isFeatureEnabled("MCVersionBasedVersioning")
             opc.getIntProperty("mcVersionElementIndex")
     )
 } else {
-    def versionNumber = opc.hasProperty("versionNumber") ? opc.getProperty("versionNumber") : "0.0.1"
-    def versionSuffix = opc.hasProperty("versionSuffix") ? opc.getProperty("versionSuffix") : "alpha"
+    def versionNumber = opc.hasPropertySet("versionNumber") ? opc.getProperty("versionNumber") : "0.0.1"
+    def versionSuffix = opc.hasPropertySet("versionSuffix") ? opc.getProperty("versionSuffix") : "alpha"
 
     if (versionSuffix == "") {
         version = versionNumber + "-" + project.exactMinecraftVersion

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1042,12 +1042,12 @@ if (opc.isFeatureEnabled("curse") && opc.hasPropertySet("curseId")
 
         mainArtifact.releaseType = opc.hasPropertySet("curseReleaseType") ? opc.getProperty("curseReleaseType") : opc.getProperty("CURSERELEASETYPE")
         if (opc.isFeatureEnabled('reformatedCurseFiles')) {
-            def mainArtifactName = rootProject.name + " - " + project.version + " - " + mainArtifact.releaseType
+            def mainArtifactName = rootProject.name
             if (opc.isFeatureEnabled('customCurseFileName')) {
                 mainArtifactName = opc.getProperty('customCurseFileName')
             }
 
-            mainArtifact.displayName = mainArtifactName
+            mainArtifact.displayName = mainArtifactName + " - " + versionNumber + " - " + mainArtifact.releaseType
         }
 
         mainArtifact.changelog = project.rootProject.file("changelog.md")
@@ -1160,12 +1160,6 @@ tasks.withType(org.gradle.api.tasks.javadoc.Javadoc.class, {task ->
 tasks.withType(Jar.class, {task ->
     task.duplicatesStrategy 'exclude'
 })
-
-tasks.register('getProjectName', Task.class) {
-    doLast {
-        print rootProject.name
-    }
-}
 
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {
     task mergeTranslations {

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1154,8 +1154,13 @@ tasks.withType(Jar.class, {task ->
     task.duplicatesStrategy 'exclude'
 })
 
-tasks.named('projectName', Task.class, { task ->
+tasks.named('getProjectName', Task.class, { task ->
     print rootProject.name
+})
+
+// TODO: REMOVE
+tasks.named('testArtifactName', Task.class, { task ->
+    println opc.getProperty('customCurseFileName') + " - " + project.version
 })
 
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1162,7 +1162,7 @@ tasks.withType(Jar.class, {task ->
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {
     task mergeTranslations {
         doLast {
-            def translationSources = project.opc.getStringListProperty("translationMergeSources");
+            def translationSources = opc.getStringListProperty("translationMergeSources");
             if (translationSources.size() >= 1) {
                 def initialSource = translationSources[0];
                 def initialFile = project.file(initialSource);

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -282,10 +282,15 @@ if (opc.isFeatureEnabled("MCVersionBasedVersioning")
             opc.getIntProperty("sourceVersionElementIndex"),
             opc.getIntProperty("mcVersionElementIndex")
     )
-}
-else
-{
-    version = System.getenv().containsKey("Version") ? System.getenv("Version") : project.modVersion
+} else {
+    def versionNumber = opc.hasProperty("versionNumber") ? opc.getProperty("versionNumber") : "0.0.1"
+    def versionSuffix = opc.hasProperty("versionSuffix") ? opc.getProperty("versionSuffix") : "alpha"
+
+    if (versionSuffix == "") {
+        version = versionNumber + "-" + project.exactMinecraftVersion
+    } else {
+        version = versionNumber + "-" + project.exactMinecraftVersion + "-" + versionSuffix
+    }
 }
 archivesBaseName = project.modId
 project.properties.file = [
@@ -1035,12 +1040,12 @@ if (opc.isFeatureEnabled("curse") && opc.hasPropertySet("curseId")
 
         mainArtifact.releaseType = opc.hasPropertySet("curseReleaseType") ? opc.getProperty("curseReleaseType") : opc.getProperty("CURSERELEASETYPE")
         if (opc.isFeatureEnabled('reformatedCurseFiles')) {
-            def mainArtifactName = rootProject.name
+            def mainArtifactName = rootProject.name + " - " + project.version + " - " + mainArtifact.releaseType
             if (opc.isFeatureEnabled('customCurseFileName')) {
                 mainArtifactName = opc.getProperty('customCurseFileName')
             }
 
-            mainArtifact.displayName = mainArtifactName + " - " + project.version
+            mainArtifact.displayName = mainArtifactName
         }
 
         mainArtifact.changelog = project.rootProject.file("changelog.md")

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -269,6 +269,15 @@ if (opc.isFeatureEnabled("GitInformation")) {
 
 group = project.modGroup
 
+def versionNumber = opc.hasPropertySet("modVersion") ? opc.getProperty("modVersion") : "0.0.1"
+def versionSuffix = opc.hasPropertySet("modVersionSuffix") ? opc.getProperty("modVersionSuffix") : "alpha"
+def versionString
+if (versionSuffix == "") {
+    versionString = versionNumber + "-" + project.exactMinecraftVersion
+} else {
+    versionString = versionNumber + "-" + project.exactMinecraftVersion + "-" + versionSuffix
+}
+
 if (opc.isFeatureEnabled("MCVersionBasedVersioning")
         && opc.hasPropertySet("mcVersionElementIndex")
         && opc.hasPropertySet("sourceVersionElementIndex")
@@ -276,21 +285,14 @@ if (opc.isFeatureEnabled("MCVersionBasedVersioning")
     logger.lifecycle("MC based versioning active")
 
     version = opc.buildVersionNumberWithOffset(
-            (System.getenv().containsKey("Version") ? System.getenv("Version") : project.modVersion),
+            versionString,
             project.exactMinecraftVersion,
             opc.getProperty("sourceVersionName"),
             opc.getIntProperty("sourceVersionElementIndex"),
             opc.getIntProperty("mcVersionElementIndex")
     )
 } else {
-    def versionNumber = opc.hasPropertySet("versionNumber") ? opc.getProperty("versionNumber") : "0.0.1"
-    def versionSuffix = opc.hasPropertySet("versionSuffix") ? opc.getProperty("versionSuffix") : "alpha"
-
-    if (versionSuffix == "") {
-        version = versionNumber + "-" + project.exactMinecraftVersion
-    } else {
-        version = versionNumber + "-" + project.exactMinecraftVersion + "-" + versionSuffix
-    }
+    version = versionString
 }
 archivesBaseName = project.modId
 project.properties.file = [

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -1157,7 +1157,7 @@ tasks.withType(Jar.class, {task ->
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {
     task mergeTranslations {
         doLast {
-            def translationSources = opc.getStringListProperty("translationMergeSources");
+            def translationSources = project.opc.getStringListProperty("translationMergeSources");
             if (translationSources.size() >= 1) {
                 def initialSource = translationSources[0];
                 def initialFile = project.file(initialSource);


### PR DESCRIPTION
Identical in core changes to #13 

Few differences:
- Version format is `"${major}.${minor}.${patch}-${{ inputs.suffix }}"` as discussed in Discord, no MC version
- MC version is returned as part of the job outputs
- New tasks in mod.gradle: `getProjectName`, used to return the `rootProject.name` so the `customCurseFileName` can be set properly
- (Temporary) A test task so I can verify in the build CI the version expected curse artifact name is as we expect it to be, because release can't be manually tested, will be removed before merge