### PR TITLE
Update all recent OPC changes back to main

### DIFF
--- a/.github/workflows/gradle.build.yaml
+++ b/.github/workflows/gradle.build.yaml
@@ -23,7 +23,8 @@ permissions:
   contents: read
 
 jobs:
-  compute-suffix:
+  generate-build-information:
+    name: "Generate build information"
     runs-on: ubuntu-latest
     outputs:
       branch_suffix: ${{ steps.computeBranchSuffix.outputs.branch_suffix }}
@@ -41,13 +42,14 @@ jobs:
           echo "branch_suffix=$cleanedBranchName" >> "$GITHUB_OUTPUT"
 
   compute-version:
-    needs: [ "compute-suffix" ]
+    needs: [ "generate-build-information" ]
     uses: ./.github/workflows/gradle.version.yaml
     with:
-      suffix: ${{ format('branch-{0}', needs.compute-suffix.outputs.branch_suffix) }}
+      suffix: ${{ needs.generate-build-information.outputs.branch_suffix }}
 
   build:
     needs: [ "compute-version" ]
+    name: "🏗️ Build"
     runs-on: ubuntu-latest
     steps:
       - id: checkout
@@ -68,6 +70,4 @@ jobs:
 
       - id: build
         name: "🏗️ Build"
-        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
-        env:
-          Version: "${{ needs.compute-version.outputs.version }}"
+        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }} -PmodVersion=${{ needs.compute-version.outputs.mod_version }} -PmodVersionSuffix=${{ needs.compute_version.outputs.suffix }}

--- a/.github/workflows/gradle.prerelease.yaml
+++ b/.github/workflows/gradle.prerelease.yaml
@@ -30,7 +30,7 @@ jobs:
   compute-version:
     uses: ./.github/workflows/gradle.version.yaml
     with:
-      suffix: pre-release
+      suffix: rc
 
   gradle:
     needs: [ "compute-version" ]
@@ -57,10 +57,9 @@ jobs:
 
       - id: build
         name: "🏗️ Build"
-        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
+        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }} -PmodVersion=${{ needs.compute-version.outputs.mod_version }} -PmodVersionSuffix=${{ needs.compute-version.outputs.suffix }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_USERNAME: ${{ github.actor }}
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
-          Version: "${{ needs.compute-version.outputs.version }}"

--- a/.github/workflows/gradle.publish.yaml
+++ b/.github/workflows/gradle.publish.yaml
@@ -44,10 +44,29 @@ permissions:
   statuses: write
 
 jobs:
+  generate-release-information:
+    name: "Generate release information"
+    runs-on: ubuntu-latest
+    outputs:
+      release_version_suffix: ${{ steps.generateReleaseSuffix.outputs.release_version_suffix }}
+    steps:
+      - id: generateReleaseSuffix
+        name: "Generate release suffix"
+        run: |
+          release_version_suffix="alpha"
+          if [[ ${{ inputs.curse_release_type }} == release ]]; then
+            release_version_suffix=""
+          elif [[ ${{ inputs.curse_release_type }} == beta ]]; then
+            release_version_suffix="snapshot"
+          fi
+          echo "Release version suffix: ${release_version_suffix}"
+          echo "release_version_suffix=${release_version_suffix}" >> "$GITHUB_OUTPUT"
+
   compute-version:
+    needs: [ "generate-release-information" ]
     uses: ./.github/workflows/gradle.version.yaml
     with:
-      suffix: ${{ inputs.curse_release_type }}
+      suffix: ${{ needs.generate-release-information.outputs.release_version_suffix }}
 
   notify-build-start:
     needs: [ "compute-version" ]
@@ -59,7 +78,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           status: 'started'
-          version: "${{ needs.compute-version.outputs.version }}"
+          version: "${{ needs.compute-version.outputs.full_version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -69,7 +88,7 @@ jobs:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: 'Publishing'
           state: 'pending'
-          description: "Version: ${{ needs.compute-version.outputs.version }}"
+          description: ${{ needs.compute-version.outputs.release_text }}
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   gradle:
@@ -96,47 +115,58 @@ jobs:
           dependency-graph: generate-and-submit
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      - id: getPreviousTag
+        name: "📝 Get previous tag"
+        run: |
+          previous_tag=$(git describe --tags --abbrev=0 HEAD)
+          echo "Previous tag: ${previous_tag}"
+          echo "previous_tag=${previous_tag}" >> "$GITHUB_OUTPUT"
+
       - id: tagLocalBuild
         name: "🏷️ Tag local build"
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "maintainer+github@ldtteam.com"
-          git tag -a ${{ needs.compute-version.outputs.version }} -m "Version ${{ needs.compute-version.outputs.version }}"
+          git tag -a "${{ needs.compute-version.outputs.tag_version }}" -m "${{ needs.compute-version.outputs.release_text }}"
 
-      - id: generate-release-changelog
+      - id: generateReleaseChangelog
         name: "📝 Generate release changelog"
-        uses: heinrichreimer/action-github-changelog-generator@v2.4
-        with:
-          output: changelog.md
-          token: ${{ secrets.GITHUB_TOKEN }}
-          stripGeneratorNotice: "true"
-          onlyLastTag: true
-          maxIssues: ${{ inputs.changelog_max_issues }}
+        run: |
+          echo "# Changelog" > changelog.md
+          echo "" >> changelog.md
+          echo "[Full Changelog](${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.getPreviousTag.outputs.previous_tag }}..${{ needs.compute-version.outputs.tag_version }})" >> changelog.md
+          echo "" >> changelog.md
+          ./gradlew --build-cache outputChangelogHeader -PmodVersion=${{ needs.compute-version.outputs.mod_version }} -PmodVersionSuffix=${{ needs.compute-version.outputs.suffix }}
+          echo "### Commits:" >> changelog.md
+          echo "" >> changelog.md
+          echo "$(git log --pretty=format:"- %s ([commit](${{ github.server_url }}/${{ github.repository }}/commit/%H))" ${{ steps.getPreviousTag.outputs.previous_tag }}..${{ needs.compute-version.outputs.tag_version }})" >> changelog.md
+          echo "" >> changelog.md
+          ./gradlew --build-cache outputChangelogFooter -PmodVersion=${{ needs.compute-version.outputs.mod_version }} -PmodVersionSuffix=${{ needs.compute-version.outputs.suffix }}
+          sed -i -E "s|\(#([[:digit:]]+)\)|([#\1](${{ github.server_url }}/${{ github.repository }}/pull/\1))|" changelog.md
 
       - id: publish
         name: "🚀 Publish"
-        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }}
+        run: ./gradlew --build-cache ${{ inputs.gradle_tasks }} -PmodVersion=${{ needs.compute-version.outputs.mod_version }} -PmodVersionSuffix=${{ needs.compute-version.outputs.suffix }}
         env:
           LDTTeamJfrogUsername: ${{ secrets.MAVEN_USER }}
           LDTTeamJfrogPassword: ${{ secrets.MAVEN_PASSWORD }}
           CURSE_API_KEY: ${{ secrets.CURSE_API_KEY }}
           CURSE_RELEASE_TYPE: ${{ inputs.curse_release_type }}
           crowdinKey: ${{ secrets.CROWDIN_API_KEY }}
-          Version: "${{ needs.compute-version.outputs.version }}"
 
       - name: "🚀 Create GitHub release"
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ needs.compute-version.outputs.version }}
-          release_name: "Release ${{ needs.compute-version.outputs.version }}"
+          tag_name: ${{ needs.compute-version.outputs.tag_version }}
+          release_name: ${{ needs.compute-version.outputs.release_text }}
           body_path: changelog.md
           prerelease: ${{ inputs.curse_release_type != 'release' }}
 
   notify-build-end:
-    name: Build notifications (end)
     needs: [ "compute-version", "notify-build-start", "gradle" ]
+    name: "🔴 Build notifications (end)"
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -145,7 +175,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ needs.gradle.result }}
-          version: "${{ needs.compute-version.outputs.version }}"
+          version: "${{ needs.compute-version.outputs.full_version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: neoforged/action-github-status@v1
@@ -154,5 +184,5 @@ jobs:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           context: 'Publishing'
           state: ${{ needs.gradle.result }}
-          description: "Version: ${{ needs.compute-version.outputs.version }}"
+          description: ${{ needs.compute-version.outputs.release_text }}
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/gradle.version.yaml
+++ b/.github/workflows/gradle.version.yaml
@@ -4,14 +4,27 @@ on:
   workflow_call:
     inputs:
       suffix:
-        description: "The suffix to finish the version string with"
-        required: false
+        description: "The release suffix"
         type: string
-        default: ""
     outputs:
-      version:
-        description: "The computed version"
-        value: ${{ jobs.compute-version.outputs.version }}
+      minecraft_version:
+        description: "The minecraft version"
+        value: ${{ jobs.compute-version.outputs.minecraft_version }}
+      mod_version:
+        description: "The mod version"
+        value: ${{ jobs.compute-version.outputs.mod_version }}
+      suffix:
+        description: "The input suffix"
+        value: ${{ inputs.suffix }}
+      full_version:
+        description: "The full version string"
+        value: ${{ jobs.compute-version.outputs.full_version }}
+      tag_version:
+        description: "The version that the tag should get"
+        value: ${{ jobs.compute-version.outputs.tag_version }}
+      release_text:
+        description: "The text for the release version"
+        value: ${{ jobs.compute-version.outputs.release_text }}
 
 permissions:
   contents: read
@@ -20,28 +33,53 @@ jobs:
   compute-version:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      minecraft_version: ${{ steps.generateMinecraftVersion.outputs.minecraft_version }}
+      mod_version: ${{ steps.generateModVersion.outputs.version }}
+      full_version: ${{ steps.generateFullVersion.outputs.full_version }}
+      tag_version: ${{ steps.generateTagVersion.outputs.tag_version }}
+      release_text: ${{ steps.generateReleaseText.outputs.release_text }}
     steps:
       - id: checkout
         name: "📦 Checkout"
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
           fetch-tags: true
 
-      - id: minecraftVersion
-        name: "📦 Extract Minecraft version"
+      - id: generateMinecraftVersion
+        name: "Generate Minecraft version"
         run: |
           cat gradle.properties | grep exactMinecraftVersion | cut -d "=" -f 2 > minecraft_version.txt
           echo "Minecraft version: $(cat minecraft_version.txt)"
           echo "minecraft_version=$(cat minecraft_version.txt)" >> "$GITHUB_OUTPUT"
 
-      - id: version
-        name: "🔢 Compute version"
+      - id: generateModVersion
+        name: "Generate mod version"
         uses: PaulHatch/semantic-version@v5.4.0
         with:
-          tag_prefix: "v"
+          tag_prefix: "v${{ steps.generateMinecraftVersion.outputs.minecraft_version }}-"
           search_commit_body: true
           debug: true
           bump_each_commit: true
-          version_format: "${{ steps.minecraftVersion.outputs.minecraft_version }}-${major}.${minor}.${patch}-${{ inputs.suffix }}"
+          version_format: "${major}.${minor}.${patch}"
+
+      - id: generateFullVersion
+        name: "Generate full version"
+        run: |
+          full_version="${{ steps.generateMinecraftVersion.outputs.minecraft_version }}-${{ steps.generateModVersion.outputs.version }}-${{ inputs.suffix }}"
+          echo "Full version: ${full_version}"
+          echo "full_version=${full_version}" >> "$GITHUB_OUTPUT"
+
+      - id: generateTagVersion
+        name: "Generate tag version"
+        run: |
+          tag_version="v${{ steps.generateMinecraftVersion.outputs.minecraft_version }}-${{ steps.generateModVersion.outputs.version }}"
+          echo "Tag version: ${tag_version}"
+          echo "tag_version=${tag_version}" >> "$GITHUB_OUTPUT"
+
+      - id: generateReleaseText
+        name: "Generate release text"
+        run: |
+          release_text="Version ${{ steps.generateModVersion.outputs.version }} for Minecraft ${{ steps.generateMinecraftVersion.outputs.minecraft_version }}"
+          echo "Release text: ${release_text}"
+          echo "release_text=${release_text}" >> "$GITHUB_OUTPUT"

--- a/gradle/mod.gradle
+++ b/gradle/mod.gradle
@@ -265,6 +265,15 @@ if (opc.isFeatureEnabled("GitInformation")) {
 
 group = project.modGroup
 
+def versionNumber = opc.hasPropertySet("modVersion") ? opc.getProperty("modVersion") : "0.0.1"
+def versionSuffix = opc.hasPropertySet("modVersionSuffix") ? opc.getProperty("modVersionSuffix") : "alpha"
+def versionString
+if (versionSuffix == "") {
+    versionString = versionNumber + "-" + project.exactMinecraftVersion
+} else {
+    versionString = versionNumber + "-" + project.exactMinecraftVersion + "-" + versionSuffix
+}
+
 if (opc.isFeatureEnabled("MCVersionBasedVersioning")
         && opc.hasPropertySet("mcVersionElementIndex")
         && opc.hasPropertySet("sourceVersionElementIndex")
@@ -272,16 +281,14 @@ if (opc.isFeatureEnabled("MCVersionBasedVersioning")
     logger.lifecycle("MC based versioning active")
 
     version = opc.buildVersionNumberWithOffset(
-            (System.getenv().containsKey("Version") ? System.getenv("Version") : project.modVersion),
+            versionString,
             project.exactMinecraftVersion,
             opc.getProperty("sourceVersionName"),
             opc.getIntProperty("sourceVersionElementIndex"),
             opc.getIntProperty("mcVersionElementIndex")
     )
-}
-else
-{
-    version = System.getenv().containsKey("Version") ? System.getenv("Version") : project.modVersion
+} else {
+    version = versionString
 }
 archivesBaseName = project.modId
 project.properties.file = [
@@ -1302,6 +1309,22 @@ tasks.withType(Jar.class, {task ->
 
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
+}
+
+tasks.register("outputChangelogHeader") {
+    def changelog = file("changelog.md")
+    def header = opc.getProperty("customChangelogHeader")
+    doLast {
+        changelog << header + "\n\n"
+    }
+}
+
+tasks.register("outputChangelogFooter") {
+    def changelog = file("changelog.md")
+    def footer = opc.getProperty("outputChangelogFooter")
+    doLast {
+        changelog << footer
+    }
 }
 
 if (opc.isFeatureEnabled("mergableTranslations") && opc.hasPropertySet("translationMergeSources") && opc.hasPropertySet("translationMergeDestination")) {


### PR DESCRIPTION
Code between ng7 and main has been updated back to be equal to eachother again.

Only difference is that the version format was changed to `mcversion-version-suffix`, which is different in ng7